### PR TITLE
runebar: no need to keep max in the rune object

### DIFF
--- a/elements/runebar.lua
+++ b/elements/runebar.lua
@@ -74,7 +74,6 @@ local Update = function(self, event, rid, energized)
 			rune:SetScript("OnUpdate", nil)
 		else
 			rune.duration = GetTime() - start
-			rune.max = duration
 			rune:SetMinMaxValues(1, duration)
 			rune:SetScript("OnUpdate", OnUpdate)
 		end


### PR DESCRIPTION
I'm sorry p3lim, I missed to clean this one up as I got caught in the discussion.